### PR TITLE
feat: add session utilities

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,50 @@
+import { v4 as uuidv4 } from 'uuid'
 import { track } from './track'
 
+// Chave utilizada no armazenamento local para identificar a sessão atual.
+const SESSION_KEY = 'ph_session_id'
+
+/**
+ * Garante que exista um identificador de sessão.
+ * Caso não exista, gera um novo UUID v4 e o salva no localStorage.
+ * @returns Identificador atual da sessão.
+ */
+export const ensureSessionId = (): string => {
+  const current = getSessionId()
+  if (current) return current
+
+  const id = uuidv4()
+  localStorage.setItem(SESSION_KEY, id)
+  return id
+}
+
+/**
+ * Obtém o identificador de sessão armazenado.
+ * @returns Identificador salvo ou string vazia caso ausente.
+ */
+export const getSessionId = (): string => {
+  return localStorage.getItem(SESSION_KEY) || ''
+}
+
+/**
+ * Gera um novo identificador de sessão, substituindo o existente.
+ * @returns Novo identificador de sessão gerado.
+ */
+export const resetSession = (): string => {
+  const id = uuidv4()
+  localStorage.setItem(SESSION_KEY, id)
+  return id
+}
+
+/**
+ * Obtém o identificador do cliente definido via variável de ambiente.
+ * Caso não seja definido, retorna "totem-unknown".
+ * @returns Identificador do cliente.
+ */
+export const getClientId = (): string => {
+  return import.meta.env.VITE_TOTEM_CLIENT_ID ?? 'totem-unknown'
+}
+
+// Funções utilitárias para rastrear início e fim de sessão no PostHog.
 export const startSession = () => track('session_start')
 export const endSession = () => track('session_end')


### PR DESCRIPTION
## Summary
- add utilities for generating, reading and resetting the PostHog session id
- expose client id from environment with fallback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm install` (fails: 403 Forbidden while fetching dependencies)
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ae598e450c8323b4a044c744584f97