### PR TITLE
feat: add PostHog init helper

### DIFF
--- a/src/posthogClient.ts
+++ b/src/posthogClient.ts
@@ -1,7 +1,32 @@
 import posthog from 'posthog-js'
+import { ensureSessionId } from './session'
 
-posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-  api_host: import.meta.env.VITE_POSTHOG_HOST
-})
+let initialized = false
 
-export default posthog
+/**
+ * Initializes PostHog with environment configuration.
+ * Ensures initialization occurs only once.
+ */
+export const initPostHog = (): void => {
+  if (initialized) return
+
+  const apiKey = import.meta.env.VITE_POSTHOG_API_KEY
+  const host = import.meta.env.VITE_POSTHOG_HOST
+
+  posthog.init(apiKey, {
+    api_host: host,
+    autocapture: false,
+    capture_pageview: true,
+  })
+
+  const sessionId = ensureSessionId()
+  posthog.identify(sessionId)
+
+  initialized = true
+}
+
+/**
+ * Returns the PostHog instance.
+ */
+export const getPosthog = () => posthog
+

--- a/src/track.ts
+++ b/src/track.ts
@@ -1,5 +1,7 @@
-import posthog from './posthogClient'
+import { initPostHog, getPosthog } from './posthogClient'
+
+initPostHog()
 
 export const track = (event: string, properties?: Record<string, any>) => {
-  posthog.capture(event, properties)
+  getPosthog().capture(event, properties)
 }


### PR DESCRIPTION
## Summary
- init PostHog with env config and session identify
- expose PostHog getter and update tracker

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "uuid" from "src/session.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68ae5a943d188323a6807fa429972138